### PR TITLE
Feat/bd_api-#32 - 빌딩 및 후기 상세 API 마무리 수정

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,9 +1,13 @@
 import styles from "./Header.module.css"
 import backIcon from "../assets/image/backIcon.svg"
 
-const Header:React.FC = () => {
+interface HeaderProps {
+  onClick?: () => void;
+}
+
+const Header:React.FC<HeaderProps> = ({onClick}) => {
     return (
-        <div className={styles.content}>
+        <div className={styles.content} onClick={onClick}>
             <img src={backIcon} alt="백버튼"/>
         </div>
     )

--- a/src/components/PreviewReview.tsx
+++ b/src/components/PreviewReview.tsx
@@ -134,7 +134,7 @@ const PreviewReview: React.FC<Props> = ({ review }) => {
                     ? "전세" // contractType이 'DEPOSIT_RENT'일 경우 표시
                     : generalInfo.contractType // 둘 다 아닐 경우 원래 값 표시
                 }{" "}
-                {generalInfo?.deposit}/{generalInfo?.monthlyRent}
+                {generalInfo?.deposit}/{generalInfo?.price}
               </div>
             )}
             {dormitoryInfo && (

--- a/src/components/detail/BuildingPreviewReview.tsx
+++ b/src/components/detail/BuildingPreviewReview.tsx
@@ -107,7 +107,7 @@ const BuildingPreviewReview: React.FC<Props> = ({ review }) => {
     <div
       className={styles.content}
       onClick={() => {
-        navigate("/building/rv");
+        navigate(`/building/review/${activeReviewInfo?.id}`);
         window.scrollTo(0, 0);
       }}
     >
@@ -164,7 +164,7 @@ const BuildingPreviewReview: React.FC<Props> = ({ review }) => {
                 ? "전세" // contractType이 'DEPOSIT_RENT'일 경우 표시
                 : generalInfo.contractType // 둘 다 아닐 경우 원래 값 표시
             }{" "}
-            {generalInfo?.deposit}/{generalInfo?.monthlyRent}
+            {generalInfo?.deposit}/{generalInfo?.price}
           </div>
         )}
         {dormitoryInfo && (

--- a/src/components/detail/BuildingReviewList.tsx
+++ b/src/components/detail/BuildingReviewList.tsx
@@ -1,83 +1,15 @@
 import { useRecoilState } from "recoil";
 import styles from "./BuildingReviewList.module.css";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import BuildingPreviewReview from "./BuildingPreviewReview";
 import { ReviewPreviewState } from "../../recoil/detail/PreviewReviewRecoilState";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { useBuildingReviewList } from "../../hooks/useBuildingReviewList";
-
-
-// const mockData = [
-//   {
-//     basicInfo: {
-//       reviewId: 1,
-//       name: "다희빌",
-//       type: "원룸",
-//       contractType: "월세",
-//       deposit: 500,
-//       monthlyRent: 45,
-//       floor: "고층",
-//       space: 26.44,
-//       maintenanceCost: 10,
-//       rating: 3,
-//       liked: true,
-//     },
-//     reviewInfo: {
-//       content: "집이 너무 깔끔하고...",
-//       keywords: ["PO_BD_LO_01", "PO_BD_MT_01", "PO_BD_LO_04"],
-//       likesCount: 120,
-//       updatedAt: new Date("2025-02-23T04:06:00.000+09:00"),
-//     },
-//     reviewImage: "http://localhost:8080/image/1.jpg",
-//   },
-//   {
-//     agencyReviewInfo: {
-//       id: 1,
-//       name: "e편한공인중개사사무소",
-//       type: "공인중개사",
-//       rating: 3,
-//       liked: true, // false
-//     },
-//     reviewInfo: {
-//       content: "집이 너무 깔끔하고...",
-//       keywords: [
-//         "PO_AG_PD_01",
-//         "PO_AG_PD_01",
-//         "NE_AG_PD_01",
-//         "PO_AG_SO_04",
-//         "NE_AG_SO_04",
-//       ],
-//       likesCount: 120,
-//       updatedAt: new Date("2025-02-23T04:06:00.000+09:00"), //yyyy-MM-dd'T'HH:mm:ss.SSSXXX
-//     },
-//     image: "http://localhost:8080/image/1.jpg",
-//   },
-//   {
-//     dormitoryBasicInfo: {
-//       id: 3, // 리뷰 ID
-//       name: "지희관",
-//       type: "기숙사",
-//       university: "경상국립대",
-//       capacity: 2,
-//       floor: "중층",
-//       space: 26.44, // area -> space 변경
-//       dormFee: 10,
-//       rating: 3,
-//       liked: true,
-//     },
-//     reviewInfo: {
-//       content: "조용하고 좋은데, 편의점이 멀어요.",
-//       keywords: ["PO_BD_ST_01", "NE_BD_LO_07", "NE_BD_LO_01", "PO_BD_ST_05"],
-//       likesCount: 45,
-//       updatedAt: new Date("2025-02-20T11:30:00.000+09:00"),
-//     },
-//     image: "http://localhost:8080/image/2.jpg",
-//   },
-// ];
 
 const BuildingReviewList: React.FC = () => {
   const { buildingId } = useParams();
   const [reviews, setReviews] = useRecoilState(ReviewPreviewState);
+  const [selectedSort, setSelectedSort] = useState<"RCMND" | "LATEST" | "LIKES" | "STARS">("RCMND");
 
 
   // 기본값: 최신순, 1페이지, 10개
@@ -105,27 +37,27 @@ const BuildingReviewList: React.FC = () => {
   if (isLoading) return <div>리뷰 불러오는 중...</div>;
   if (isError) return <div>리뷰 불러오기 실패</div>;
 
-  console.log("리코일 저장 후 리뷰", reviews);
-
-
-  // useEffect(() => {
-  //   setReviews(mockData);
-  // }, []);
-
   return (
     <div className={styles.content}>
       <div className={styles.filterWrap}>
-        <>
-          <p className={styles.selectedText}>
-            <span>•</span>최신순
-          </p>
-          <p>
-            <span>•</span>좋아요순
-          </p>
-          <p>
-            <span>•</span>별점순
-          </p>
-        </>
+          {[
+              { label: "추천순", value: "RCMND" },
+              { label: "최신순", value: "LATEST" },
+              { label: "좋아요순", value: "LIKES" },
+              { label: "별점순", value: "STARS" },
+          ].map((sortOption) => (
+              <p
+              key={sortOption.value}
+              className={
+                  selectedSort === sortOption.value
+                  ? styles.selectedText
+                  : undefined
+              }
+              onClick={() => setSelectedSort(sortOption.value as typeof selectedSort)}
+              >
+              <span>•</span>{sortOption.label}
+              </p>
+          ))}
       </div>
       {/* 리뷰 */}
       {reviews.map((review) => (
@@ -137,7 +69,7 @@ const BuildingReviewList: React.FC = () => {
           }
         >
           <div className={styles.line} />
-          {/* <BuildingPreviewReview review={review} /> */}
+          <BuildingPreviewReview review={review} />
         </div>
       ))}
     </div>

--- a/src/components/util/ReportButton.tsx
+++ b/src/components/util/ReportButton.tsx
@@ -6,7 +6,11 @@ import reportModalIcon from "../../assets/image/ReportModalIcon.svg"
 import verifyCompleteIcon from "../../assets/image/verifyCompleteIcon.svg"
 import { useLocation, useNavigate } from "react-router-dom"
 
-const ReportButton:React.FC = () => {
+type Props = {
+    reviewId : string | undefined;
+}
+
+const ReportButton:React.FC<Props> = ({reviewId}) => {
     const [isOpen, setIsOpen] = useState(false)
     const [isReported, setIsReported] = useState(false)
 
@@ -14,7 +18,8 @@ const ReportButton:React.FC = () => {
     const locate = useLocation();
 
     const handleButtonClick = () => {
-        navigate('/building/rv/report', { state: locate.state });
+        navigate(`/building/review/${reviewId}/report`, { state: locate.state });
+        setIsOpen(true);
       };
 
     return (

--- a/src/pages/Building.tsx
+++ b/src/pages/Building.tsx
@@ -9,132 +9,11 @@ import { useRecoilState, useRecoilValue } from "recoil";
 import { BuildingInfoState } from "../recoil/detail/BuildingRecoilState";
 import exampleImage1 from '../assets/image/example_image1.png';
 import exampleImage2 from '../assets/image/example_image2.png';
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { useBuildingDetail } from "../hooks/useBuildingDetail";
 
-// const mockData = {
-//     basicInfo: {
-//         liked: true,
-//         id: 3,
-//         type: ["아파트", "원룸"],
-//         name: "진주가좌그린빌 주공아파트",
-//         address: "경남 진주시 내동로348번길 10 [가좌동 573-10]",
-//         rating: 3,
-//         reviewCount: 25
-//     },
-//     buildingImages: {
-//         count: 2,
-//         imageUrl: [
-//             exampleImage1,exampleImage2,exampleImage1,exampleImage1,exampleImage2,
-//         ]
-//     },
-//     keywords: [ // 키워드 정보
-//                 {
-//                     "key": "PO_BD_LO_01",
-//                     "count": 10
-//                 },
-//                 {
-//                     "key": "PO_BD_LO_02",
-//                     "count": 6
-//                 },
-//                 {
-//                     "key": "PO_BD_MT_01",
-//                     "count": 4
-//                 },
-//                 {
-//                     "key": "PO_BD_MT_04",
-//                     "count": 3
-//                 },
-//                 {
-//                     "key": "PO_BD_ST_01",
-//                     "count": 2
-//                 },
-//             ],
-// }
-
-// const mockData = {
-//     basicInfo: {
-//         liked: true,
-//         id: 3,
-//         type: ["공인중개사"],
-//         name: "e편한공인중개사사무소",
-//         address: "경남 진주시 내동로348번길 10 [가좌동 573-10]",
-//         rating: 3,
-//         reviewCount: 25
-//     },
-//     buildingImages: {
-//         count: 2,
-//         imageUrl: [
-//             exampleImage1,exampleImage2,exampleImage1,exampleImage1,exampleImage2,
-//         ]
-//     },
-//     keywords: [ // 키워드 정보
-//                 {
-//                     "key": "PO_AG_PD_01",
-//                     "count": 10
-//                 },
-//                 {
-//                     "key": "PO_AG_PD_02",
-//                     "count": 6
-//                 },
-//                 {
-//                     "key": "PO_AG_SO_01",
-//                     "count": 4
-//                 },
-//                 {
-//                     "key": "PO_AG_SO_02",
-//                     "count": 3
-//                 },
-//                 {
-//                     "key": "PO_AG_SO_05",
-//                     "count": 2
-//                 },
-//             ],
-// }
-
-
-// const mockData = {
-//     basicInfo: {
-//         liked: true,
-//         id: 3,
-//         type: ["기숙사"],
-//         name: "지희관",
-//         campus:"경상국립대 칠암캠퍼스",
-//         address: "경남 진주시 내동로348번길 10 [가좌동 573-10]",
-//         rating: 3,
-//         reviewCount: 25
-//     },
-//     buildingImages: {
-//         count: 2,
-//         imageUrl: [
-//             exampleImage1,exampleImage2,exampleImage1,exampleImage1,exampleImage2,
-//         ]
-//     },
-//     keywords: [ // 키워드 정보
-//                 {
-//                     "key": "PO_DM_LO_01",
-//                     "count": 10
-//                 },
-//                 {
-//                     "key": "PO_MT_02",
-//                     "count": 6
-//                 },
-//                 {
-//                     "key": "PO_MT_03",
-//                     "count": 4
-//                 },
-//                 {
-//                     "key": "PO_MT_04",
-//                     "count": 3
-//                 },
-//                 {
-//                     "key": "PO_MT_05",
-//                     "count": 2
-//                 },
-//             ],
-// }
-
 const Building: React.FC = () => {
+    const navigate = useNavigate();
     const [windowHeight, setWindowHeight] = useState(window.innerHeight);
     const [buildingInfo, setBuildingInfo] = useRecoilState(BuildingInfoState);
     
@@ -142,10 +21,6 @@ const Building: React.FC = () => {
     const isAgency = false; // 필요 시 로직으로 결정
 
     const { data, isLoading, isError } = useBuildingDetail(buildingId!, isAgency);
-
-    // useEffect(() => {
-    //     setBuildingInfo(mockData);
-    // }, []);
 
     useEffect(() => {
         if (!data) return;
@@ -181,12 +56,16 @@ const Building: React.FC = () => {
     if (isLoading) return <div>로딩 중...</div>;
     if (isError) return <div>데이터를 불러오는 중 오류가 발생했습니다.</div>;
     
+    const handleBack = () => {
+        navigate(-1);
+    };
+    
     return (
         <div className={styles.content}
         style={{ minHeight: `${windowHeight}px`, display: "flex", flexDirection: "column" }}>
             <div className={styles.container}>
                 {/* 헤더 */}
-                <Header/>
+                <Header onClick={handleBack}/>
                 {/* 이미지슬라이더 */}
                 <ImageSlider building={building} review={null}/>
                 {/* 건물 정보 및 키워드 */}

--- a/src/pages/ReportPage.tsx
+++ b/src/pages/ReportPage.tsx
@@ -1,4 +1,4 @@
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 import styles from "./ReportPage.module.css"
 import closeIcon from '../assets/image/iconClose.svg';
 import { useLayoutEffect, useRef, useState } from "react";
@@ -51,16 +51,18 @@ const ReportPage: React.FC = () => {
     const [content, setContent] = useState('');
 
     const maxLength = 1000;
-      
+
+    const { reviewId } = useParams();
+          
     const handleContentChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
         if (e.target.value.length <= maxLength) {
           setContent(e.target.value);
         }
       };
       
-      const handleButtonClick = () => {
-        navigate('/building/rv', { state: location.state });
-      };
+    const handleButtonClick = () => {
+        navigate(`/building/review/${reviewId}`, { state: location.state });
+    };
 
     return (
         <div className="content">

--- a/src/pages/Review.tsx
+++ b/src/pages/Review.tsx
@@ -13,11 +13,12 @@ import ReportButton from '../components/util/ReportButton';
 import exampleImage1 from '../assets/image/example_image1.png';
 import exampleImage2 from '../assets/image/example_image2.png';
 import ReviewFacilitiesInfo from '../components/detail/ReviewFacilitiesInfo';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { useReviewDetail } from '../hooks/useReviewDetail';
 
 
 const Review: React.FC = () => {
+    const navigate = useNavigate();
     const [windowHeight, setWindowHeight] = useState(window.innerHeight);
     const [reviews, setReviews] = useRecoilState(ReviewInfoState);
     
@@ -48,6 +49,10 @@ const Review: React.FC = () => {
         }
     }, [data]);
         
+    const handleBack = () => {
+        navigate(-1);
+    };
+
     if (isLoading) return <div>로딩 중...</div>;
     if (isError || !data) return <div>리뷰 정보를 불러오지 못했습니다.</div>;
 
@@ -57,7 +62,7 @@ const Review: React.FC = () => {
         style={{ minHeight: `${windowHeight}px`, display: "flex", flexDirection: "column" }}>
             <div className={styles.container}>
                 {/* 헤더 */}
-                <Header/>
+                <Header onClick={handleBack}/>
                 {/* 이미지슬라이더 */}
                 <ImageSlider review={reviews} building={null}/>
                 {/* 리뷰 정보 및 키워드 */}

--- a/src/pages/Review.tsx
+++ b/src/pages/Review.tsx
@@ -94,7 +94,7 @@ const Review: React.FC = () => {
                 </div>
                 : 
                 <div className={styles.fixedWrap}>
-                    <ReportButton/>
+                    <ReportButton reviewId = {reviewId}/>
                     <TopButton/>
                 </div>
             }

--- a/src/recoil/detail/PreviewReviewRecoilState.ts
+++ b/src/recoil/detail/PreviewReviewRecoilState.ts
@@ -7,7 +7,7 @@ export interface GeneralReviewInfo {
   type: string;
   contractType: string;
   deposit: number; // 보증금
-  monthlyRent: number; // 월세
+  price: number; // 월세
   floor: string;
   space: number; // area -> space 변경
   maintenanceCost: number;


### PR DESCRIPTION
## 📌 이슈 번호
> ex) #32 

## 💬 리뷰 포인트
> 빌딩 및 후기 상세 리스트 표시, 네비게이션 수정

## 🚀 상세 설명
- 빌딩 상세 api 연결
- 후기 상세 api 연결
- 네비게이션 연결
- previewBuildingReview 수정
- 영어->한글 매핑

## 📸 스크린샷
<img width="305" height="657" alt="스크린샷 2025-07-27 오전 8 35 20" src="https://github.com/user-attachments/assets/38a5d6cf-530e-4459-959a-f052719fd999" />
<img width="303" height="656" alt="스크린샷 2025-07-27 오전 8 35 34" src="https://github.com/user-attachments/assets/110f643d-c4c7-49d6-8f62-0683d8d959bc" />
<img width="303" height="659" alt="스크린샷 2025-07-27 오전 8 35 41" src="https://github.com/user-attachments/assets/3071b9c8-6727-4a41-86eb-c4045bc109ca" />
<img width="302" height="652" alt="스크린샷 2025-07-27 오전 8 35 48" src="https://github.com/user-attachments/assets/6f5b77a1-0988-4c03-a25c-c1127f0f081c" />

## 📢 노트
