### PR TITLE
Feature&Hotfix : 신입생 재인증 팝업 UI 및 기능 구현

### DIFF
--- a/src/components/util/Popup.module.css
+++ b/src/components/util/Popup.module.css
@@ -1,0 +1,99 @@
+.sheet {
+    box-sizing: border-box;
+    position: fixed; /* 고정 위치 */
+
+    width: 100%;
+    max-width: 393px;
+    padding: 16px 16px;
+    padding-bottom: 34px;
+
+    background-color: var(--white);
+    z-index: 10000; /* 가장 앞에 보이도록 설정 */
+    display: flex;
+    flex-direction: column;
+    border-radius: 20px;
+    gap: 8px;
+
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+}
+
+.overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(23, 23, 23,0.5);
+    z-index: 9999;
+    opacity: 1;
+}
+
+.sheet_title_wrap {
+    display: block;
+    width: 100%;
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    z-index: 9999;
+}
+
+.sheet_content {
+    margin: 0;
+    padding: 0;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap:34px;
+}
+
+.sheet_text_wrap {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap:4px;
+}
+
+.sheet_text_title {
+    font-size: 20px;
+    font-weight: 700;
+    color: var(--black);
+    letter-spacing: -0.6px;
+    line-height: 1.6;
+}
+
+.sheet_text_body {
+    font-size: 16px;
+    font-weight: 400;
+    color: var(--color-gray60);
+    letter-spacing: -0.6px;
+    line-height: 1.5;
+    text-align: center;
+}
+
+.sheet_button {
+    width: 100%;
+    height: 54px;
+    background-color: var(--primary-color);
+    border-radius: 13px;
+    color: var(--white);
+    font-size: 16px;
+    font-weight: 500;
+    line-height: 22px;
+    letter-spacing: -0.6px;
+    text-align: center;
+    border: none;
+}
+
+.info {
+    font-size: 12px;
+    font-weight: 400;
+    color: var(--primary-color);
+    letter-spacing: -0.6px;
+    line-height: 1.5;
+    text-align: center;
+    margin-top:36px;
+}

--- a/src/components/util/Popup.tsx
+++ b/src/components/util/Popup.tsx
@@ -1,0 +1,57 @@
+import styles from './Popup.module.css';
+import iconClose from "../../assets/image/iconClose.svg"
+import characterIcon from "../../assets/image/emptyCharacterIcon.svg"
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY = "home_popup_hidden_until";
+const HIDE_MS = 24 * 60 * 60 * 1000; // 24시간
+// const HIDE_MS = 30 * 1000;
+
+const PopupSheet = () => { {
+    const [isOpenPopup, setIsOpenPopup] = useState(true);
+
+    useEffect(() => {
+        const hiddenUntil = Number(localStorage.getItem(STORAGE_KEY) || "0");
+        const now = Date.now();
+
+        // 아직 숨김 기간이면 닫힌 상태 유지
+        if (now < hiddenUntil) {
+            setIsOpenPopup(false);
+            return;
+        }
+
+        // 숨김 기간이 아니면 오픈
+        setIsOpenPopup(true);
+    }, []);
+
+
+    const closeModal = () => {
+        const hiddenUntil = Date.now() + HIDE_MS;
+        localStorage.setItem(STORAGE_KEY, String(hiddenUntil));
+        setIsOpenPopup(false);
+    };
+
+    if (!isOpenPopup) return null;
+    
+    return (
+        <>
+        <div className={styles.overlay} onClick={closeModal}/>
+        <div className={styles.sheet}>
+            <div className={styles.sheet_title_wrap}>
+                <img src={iconClose} width="24px" onClick={closeModal} role="button" alt='close'/>
+            </div>
+            <div className={styles.sheet_content}>
+                <div className={styles.sheet_text_wrap}>
+                    <p className={styles.sheet_text_title}>1/15~16일 신입생 인증 재요청</p>
+                    <p className={styles.sheet_text_body}>서버 오류로 해당 기간 인증 내역이 유실되었습니다.<br/>대상자분들은 다시 한번 인증 부탁드립니다.<br/>불편을 드려 정말 죄송합니다</p>
+                </div>
+                <img src={characterIcon} width="180px"alt='character'/>
+            </div>
+            <p className={styles.info}>확인이나 X를 누르시면 24시간동안 팝업이 보이지 않습니다.</p>
+            <button className={styles.sheet_button} onClick={closeModal}>확인</button>
+        </div>
+        </>
+    );
+}};
+
+export default PopupSheet;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -15,6 +15,7 @@ import { isLoginState } from '../recoil/auth/isLoginState';
 import { useRecoilValue } from 'recoil';
 import MetaTag from '../util/SEOMetaTag';
 import BannerCarousel from '../components/BannerCarousel';
+import PopupSheet from '../components/util/Popup';
 
 const getReviewKey = (review: any) => {
   if (review.generalReviewInfo) return `general-${review.generalReviewInfo.id}`;
@@ -235,6 +236,8 @@ const Home: React.FC = () => {
       </div>
       <div />
     </div>
+
+    <PopupSheet/>
     </>
   );
 };


### PR DESCRIPTION
## 📌 이슈 번호
> ex) #114 

## 💬 리뷰 포인트
> 서버 오류로 인한 신입생 인증 데이터 소실에 따른 재인증 안내 팝업 구현

## 🚀 상세 설명
> 재인증 안내 팝업을 구현하여 확인, X 클릭시 24시간동안은 나타나지않게 기능 구현함.

## 📸 스크린샷
<img width="344" height="680" alt="image" src="https://github.com/user-attachments/assets/1cbb2247-fd9d-4ec4-89b7-cdf6d407a6bf" />


## 📢 노트
